### PR TITLE
A Minor Feature : Support for Tap and Drag Menu View through Ellipsis button

### DIFF
--- a/MGTileMenu/MGTileMenuController.h
+++ b/MGTileMenu/MGTileMenuController.h
@@ -46,6 +46,7 @@
 @property (nonatomic, strong) UIImage *pageButtonImage; // default: nil (which renders an ellipsis "...")
 @property (nonatomic) BOOL shouldMoveToStayVisibleAfterRotation; // whether the menu should automatically move to remain fully visible after the device has been rotated (default: YES)
 @property (nonatomic) BOOL closeButtonVisible; // whether the close button is visible (default: YES). If NO, the user can still dismiss the menu by tapping outside its bounds (which you can also disable via the tileMenuShouldDismiss: delegate method)
+@property (nonatomic) BOOL enableTapDragOnEllipsis;// enables the user to tap and drag on Ellipsis button to move the Menu View 
 
 
 // Creation.

--- a/MGTileMenu/MGTileMenuController.m
+++ b/MGTileMenu/MGTileMenuController.m
@@ -1141,6 +1141,8 @@ CGGradientRef MGCreateGradientWithColors(UIColor *topColorRGB, UIColor *bottomCo
 		CGRect menuViewFrame = self.view.frame;
 		menuViewFrame.origin.x += tranlation.x;
 		menuViewFrame.origin.y += tranlation.y;
+		//we ensure that the menu does fully overlap ( contains within ) the outer rect
+		menuViewFrame = MGMinimallyOverlapRects(menuViewFrame, _parentView.bounds,MG_PARENTVIEW_EDGE_INSET );
 		[self.view setFrame:menuViewFrame];
 		
 		//reset the translation as we have read the value

--- a/MGTileMenu/MGTileMenuController.m
+++ b/MGTileMenu/MGTileMenuController.m
@@ -61,6 +61,7 @@ NSString *MGTileMenuDidSwitchToPageNotification;
 @synthesize pageButtonImage = _pageButtonImage;
 @synthesize shouldMoveToStayVisibleAfterRotation = _shouldMoveToStayVisibleAfterRotation;
 @synthesize closeButtonVisible = _closeButtonVisible;
+@synthesize enableTapDragOnEllipsis = _enableTapDragOnEllipsis;
 
 
 #pragma mark - Creation and destruction
@@ -112,6 +113,7 @@ NSString *MGTileMenuDidSwitchToPageNotification;
 						  nil];
 		
 		_singlePageMaxTiles = NO;
+		_enableTapDragOnEllipsis = NO;
     }
     return self;
 }
@@ -211,6 +213,15 @@ NSString *MGTileMenuDidSwitchToPageNotification;
 			UIImage *tileHighlightedImage = [self tileBackgroundImageHighlighted:YES];
 			[tileButton setBackgroundImage:tileImage forState:UIControlStateNormal];
 			[tileButton setBackgroundImage:tileHighlightedImage forState:UIControlStateHighlighted];
+			
+			//bharath2020 - added this - to enable tap and drag on ellipsis button to move the menu
+			if( _enableTapDragOnEllipsis )
+			{
+				//listen to drag events on ellipsis button
+				UIPanGestureRecognizer *dragGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(tapDrag:)];
+				[tileButton addGestureRecognizer:dragGesture];
+			}
+			
 		} else {
 			j = [[_animationOrder objectAtIndex:i] integerValue];
 			if (_rightHanded) {
@@ -1112,5 +1123,29 @@ CGGradientRef MGCreateGradientWithColors(UIColor *topColorRGB, UIColor *bottomCo
 	}
 }
 
+
+//bharath2020-added this
+- (void)tapDrag:(UIPanGestureRecognizer*)panGesture
+{
+	if( panGesture.state == UIGestureRecognizerStateEnded )
+	{
+		//drag end - so reset the highlight
+		[(UIButton*)panGesture.view setHighlighted:NO];
+	}
+	else 
+	{
+		//drag start or in movement
+		[(UIButton*)panGesture.view setHighlighted:YES];
+		
+		CGPoint tranlation = [panGesture translationInView:self.view];
+		CGRect menuViewFrame = self.view.frame;
+		menuViewFrame.origin.x += tranlation.x;
+		menuViewFrame.origin.y += tranlation.y;
+		[self.view setFrame:menuViewFrame];
+		
+		//reset the translation as we have read the value
+		[panGesture setTranslation:CGPointZero inView:self.view];
+	}
+}
 
 @end

--- a/MGTileMenu/MGTileMenuController.m
+++ b/MGTileMenu/MGTileMenuController.m
@@ -214,7 +214,7 @@ NSString *MGTileMenuDidSwitchToPageNotification;
 			[tileButton setBackgroundImage:tileImage forState:UIControlStateNormal];
 			[tileButton setBackgroundImage:tileHighlightedImage forState:UIControlStateHighlighted];
 			
-			//bharath2020 - added this - to enable tap and drag on ellipsis button to move the menu
+			//enable tap and drag on ellipsis button to move the menu
 			if( _enableTapDragOnEllipsis )
 			{
 				//listen to drag events on ellipsis button
@@ -1124,7 +1124,6 @@ CGGradientRef MGCreateGradientWithColors(UIColor *topColorRGB, UIColor *bottomCo
 }
 
 
-//bharath2020-added this
 - (void)tapDrag:(UIPanGestureRecognizer*)panGesture
 {
 	if( panGesture.state == UIGestureRecognizerStateEnded )

--- a/MGTileMenu/MGTileMenuController.m
+++ b/MGTileMenu/MGTileMenuController.m
@@ -1141,6 +1141,7 @@ CGGradientRef MGCreateGradientWithColors(UIColor *topColorRGB, UIColor *bottomCo
 		CGRect menuViewFrame = self.view.frame;
 		menuViewFrame.origin.x += tranlation.x;
 		menuViewFrame.origin.y += tranlation.y;
+		
 		//we ensure that the menu does fully overlap ( contains within ) the outer rect
 		menuViewFrame = MGMinimallyOverlapRects(menuViewFrame, _parentView.bounds,MG_PARENTVIEW_EDGE_INSET );
 		[self.view setFrame:menuViewFrame];

--- a/MGTileMenu/MLGViewController.m
+++ b/MGTileMenu/MLGViewController.m
@@ -19,7 +19,7 @@
 
 - (NSInteger)numberOfTilesInMenu:(MGTileMenuController *)tileMenu
 {
-	return 9;
+	return 11;
 }
 
 
@@ -153,6 +153,8 @@
 			if (!tileController) {
 				// Create a tileController.
 				tileController = [[MGTileMenuController alloc] initWithDelegate:self];
+				//bharath2020 - lets enable the tap drag feature
+				tileController.enableTapDragOnEllipsis = YES;
 				tileController.dismissAfterTileActivated = NO; // to make it easier to play with in the demo app.
 			}
 			// Display the TileMenu.

--- a/MGTileMenu/MLGViewController.m
+++ b/MGTileMenu/MLGViewController.m
@@ -19,7 +19,7 @@
 
 - (NSInteger)numberOfTilesInMenu:(MGTileMenuController *)tileMenu
 {
-	return 6;
+	return 9;
 }
 
 

--- a/MGTileMenu/MLGViewController.m
+++ b/MGTileMenu/MLGViewController.m
@@ -19,7 +19,7 @@
 
 - (NSInteger)numberOfTilesInMenu:(MGTileMenuController *)tileMenu
 {
-	return 11;
+	return 6;
 }
 
 

--- a/MGTileMenu/MLGViewController.m
+++ b/MGTileMenu/MLGViewController.m
@@ -153,7 +153,7 @@
 			if (!tileController) {
 				// Create a tileController.
 				tileController = [[MGTileMenuController alloc] initWithDelegate:self];
-				//bharath2020 - lets enable the tap drag feature
+				//lets enable the tap drag feature
 				tileController.enableTapDragOnEllipsis = YES;
 				tileController.dismissAfterTileActivated = NO; // to make it easier to play with in the demo app.
 			}


### PR DESCRIPTION
Added a new property named 'enableTapDragOnEllipsis'  property to MGTileMenuController which allow the user to tap and drag the menu view using ellipsis button. By Default, it is set to 'false'.

Could not think of a better idea to enable this feature while number of tiles are less than 6.
