### PR TITLE
disable tiles when dismissing

### DIFF
--- a/MGTileMenu/MGTileMenuController.m
+++ b/MGTileMenu/MGTileMenuController.m
@@ -546,6 +546,7 @@ CGGradientRef MGCreateGradientWithColors(UIColor *topColorRGB, UIColor *bottomCo
 	
 	// Dismiss if appropriate.
 	if (self.dismissAfterTileActivated) {
+		[self setAllTilesInteractionEnabled:NO];
 		[self performSelector:@selector(dismissMenu) withObject:nil afterDelay:MG_ACTIVATION_DISMISS_DELAY];
 	}
 }


### PR DESCRIPTION
In my case, I use MGTileMenu to switch views. I need to set dismissAfterTileActivated=Yes, while the tile menu are dismissing, users may accidently trigger a tile twice and the tile menu will make duplicated reactions. so I just disable tiles when dismissing after a tile is activated.
